### PR TITLE
feat: auto-compile TypeScript for Release Please PRs

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,0 +1,69 @@
+name: Build TypeScript for Release PRs
+
+# This workflow ensures Release Please PRs include freshly compiled TypeScript
+# so that releases always have up-to-date compiled assets.
+#
+# Triggers on Release Please PRs (branch pattern: release-please--*)
+# and rebuilds/commits the TypeScript if needed.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-and-commit:
+    # Only run for Release Please PRs
+    if: startsWith(github.head_ref, 'release-please--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.20.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Check for changes in compiled scripts
+        id: changes
+        run: |
+          if [ -n "$(git status --porcelain scripts-dist/)" ]; then
+            echo "changes=true" >> $GITHUB_OUTPUT
+            echo "Compiled scripts need updating"
+            git status --porcelain scripts-dist/
+          else
+            echo "changes=false" >> $GITHUB_OUTPUT
+            echo "Compiled scripts are up to date"
+          fi
+
+      - name: Commit updated scripts
+        if: steps.changes.outputs.changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add scripts-dist/
+          git commit -m "build: update compiled TypeScript for release
+
+          Automatically compiled fresh TypeScript sources before release"
+          git push
+
+          echo "✅ Compiled scripts updated and committed to release PR"


### PR DESCRIPTION
## Summary
Adds a workflow that automatically rebuilds and commits TypeScript when Release Please creates or updates a release PR, ensuring releases always have fresh compiled assets.

## How it works
- Triggers on PRs from `release-please--*` branches
- Builds TypeScript and runs tests
- Commits updated `scripts-dist/` if changes detected

## Why
Prevents releases from shipping stale compiled assets when TypeScript source changes haven't been rebuilt.