### PR TITLE
feat(release): pass through release-please config/manifest inputs

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -18,6 +18,14 @@ inputs:
   release-token:
     description: 'Personal Access Token (PAT) for Release Please. Required for creating PRs. Must be passed as a secret (e.g., secrets.RELEASE_PAT)'
     required: true
+  config-file:
+    description: 'Path to release-please config file. Defaults to release-please-config.json'
+    required: false
+    default: 'release-please-config.json'
+  manifest-file:
+    description: 'Path to release-please manifest file. Defaults to .release-please-manifest.json'
+    required: false
+    default: '.release-please-manifest.json'
   create-version-aliases:
     description: 'Create major/minor version aliases (e.g., v1 -> v1.2.3, v1.2 -> v1.2.3). Defaults to false for reproducible builds.'
     required: false
@@ -44,6 +52,8 @@ runs:
       with:
         token: ${{ inputs.release-token }}
         release-type: go
+        config-file: ${{ inputs.config-file }}
+        manifest-file: ${{ inputs.manifest-file }}
         package-name: ''
         
     - name: Check Release Please outputs


### PR DESCRIPTION
## Summary
- Add optional `config-file` and `manifest-file` inputs to the release action
- Forward them to `release-please-action@v4.2.0`, enabling non-default config paths
- Defaults match release-please conventions (`release-please-config.json` and `.release-please-manifest.json`)

Closes #39

## Test plan
- [ ] Verify existing workflows without these inputs continue to work (defaults match release-please auto-detection)
- [ ] Test with explicit non-default paths in a consuming workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)