### PR TITLE
feat: enforce caller-provided checkout across all actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,7 @@ When setting up go-actions for a new Go project, follow this complete checklist.
 - Optionally create `.go-actions.yaml` for custom CI configuration
 
 **2. Release Setup (do this alongside CI, not later):**
-- Create `.github/workflows/release.yaml` using `jrschumacher/go-actions/release@v3`
+- Create `.github/workflows/release.yaml` with `actions/checkout@v4` (with `fetch-depth: 0` and `token`) followed by `jrschumacher/go-actions/release@v3`
 - Create `.release-please-config.json`:
   ```json
   {

--- a/README.md
+++ b/README.md
@@ -76,12 +76,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - uses: jrschumacher/go-actions/release@v3
         with:
           release-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 ```
 
-**Required**: Create a PAT with `contents:write` and `pull_requests:write` permissions. Add as `RELEASE_PLEASE_TOKEN` secret.
+**Required**: Create a PAT with `contents:write` and `pull_requests:write` permissions. Add as `RELEASE_PLEASE_TOKEN` secret. The checkout step must use `fetch-depth: 0` (full history) and the same PAT as its `token`.
 
 ---
 
@@ -224,11 +228,19 @@ Before using, create these files in your repository:
 
 ```yaml
 # Basic release
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+    token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 - uses: jrschumacher/go-actions/release@v3
   with:
     release-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
 # With version aliases (v1 -> v1.2.3)
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+    token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 - uses: jrschumacher/go-actions/release@v3
   with:
     release-token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/adr/001-caller-provides-checkout.md
+++ b/adr/001-caller-provides-checkout.md
@@ -1,0 +1,56 @@
+# ADR-001: Caller Provides Checkout
+
+**Status:** Accepted
+**Date:** 2026-03-06
+
+## Context
+
+go-actions provides three composite actions: `ci`, `release`, and `self-validate`. Prior to v3, the approach to repository checkout was inconsistent:
+
+- `ci` and `self-validate` expected the caller to checkout
+- `release` performed checkout internally (with `fetch-depth: 0` and the PAT token)
+
+This inconsistency caused confusion during v1-to-v3 migrations, where users forgot to add `actions/checkout@v4` before `self-validate@v3`.
+
+## Decision
+
+All go-actions composite actions require the caller to perform `actions/checkout` before invoking the action. No action performs checkout internally.
+
+## Rationale
+
+1. **Composability** — Callers often need to customize checkout (submodules, fetch-depth, LFS, sparse-checkout, tokens). Internal checkout either blocks these options or forces the action to proxy every `actions/checkout` input.
+
+2. **No surprise side effects** — Composite actions that silently checkout can conflict with earlier checkout steps or working-directory setups.
+
+3. **Convention** — Most well-maintained composite actions (golangci-lint-action, goreleaser-action, etc.) expect the repo to already be checked out.
+
+4. **Transparency** — The workflow file clearly shows what's happening at each step.
+
+5. **Consistency** — A single rule ("always checkout first") is easier to document and remember than per-action exceptions.
+
+## Consequences
+
+### For `ci` and `self-validate`
+
+No change — these already required caller-provided checkout.
+
+### For `release`
+
+The internal checkout step is removed. Callers must provide checkout with the correct parameters:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0
+      token: ${{ secrets.RELEASE_PAT }}
+  - uses: jrschumacher/go-actions/release@v3
+    with:
+      release-token: ${{ secrets.RELEASE_PAT }}
+```
+
+Both `fetch-depth: 0` (full history for release-please) and `token` (PAT for pushing release commits) are required. The `self-validate` action will check for these and warn if they are missing or misconfigured.
+
+### Migration
+
+This is a breaking change for `release` users upgrading within v3. The self-validate action should detect missing checkout steps and provide guidance in PR comments.

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -34,12 +34,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        token: ${{ inputs.release-token }}
-
     - name: Set up Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Summary

All go-actions composite actions now require callers to provide `actions/checkout` before invoking the action. This removes the internal checkout from `release/action.yaml` to maintain consistency with `ci` and `self-validate`.

## Changes

- Remove internal checkout from release action (callers must provide `fetch-depth: 0` and PAT token)
- Add ADR-001 documenting the decision and rationale
- Update README examples to show required checkout steps  
- Update CLAUDE.md project setup checklist

The single rule "always checkout first" eliminates confusion during v1-to-v3 migrations where users forgot to add `actions/checkout@v4` before `self-validate@v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)