### PR TITLE
feat: surface test output in CI action for better diagnostics

### DIFF
--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -196,6 +196,15 @@ runs:
           [ "$issues" != "0" ] && [ "$issues" != "null" ] && echo "  Issues: ${issues}"
           [ "$vulns" != "0" ] && [ "$vulns" != "null" ] && echo "  Vulnerabilities: ${vulns}"
           [ -n "$message" ] && [ "$message" != "null" ] && echo "  Message: ${message}"
+
+          # Display command output if present (e.g., test failure details)
+          check_output=$(jq -r '.checks[0].output // ""' /tmp/result.json)
+          if [ -n "$check_output" ] && [ "$check_output" != "null" ]; then
+            echo ""
+            echo "--- Command Output ---"
+            echo "$check_output"
+            echo "--- End Command Output ---"
+          fi
         else
           echo "status=error" >> $GITHUB_OUTPUT
           echo "coverage=0" >> $GITHUB_OUTPUT

--- a/cli/internal/output/formatter.go
+++ b/cli/internal/output/formatter.go
@@ -17,6 +17,7 @@ type CheckResult struct {
 	Threshold     float64       `json:"threshold,omitempty"`
 	Vulnerabilities int         `json:"vulnerabilities,omitempty"`
 	Message       string        `json:"message,omitempty"`
+	Output        string        `json:"output,omitempty"`
 }
 
 // Results represents all check results
@@ -88,6 +89,12 @@ func (f *Formatter) printText(results *Results) error {
 
 		if _, err := fmt.Fprintln(f.writer, line); err != nil {
 			return fmt.Errorf("failed to write check result: %w", err)
+		}
+
+		if check.Output != "" {
+			if _, err := fmt.Fprintf(f.writer, "\n%s\n", check.Output); err != nil {
+				return fmt.Errorf("failed to write check output: %w", err)
+			}
 		}
 	}
 

--- a/cli/internal/runner/lint.go
+++ b/cli/internal/runner/lint.go
@@ -58,6 +58,7 @@ func (r *Runner) RunLint() (output.CheckResult, error) {
 		if err != nil {
 			result.Status = "error"
 			result.Message = "lint check failed"
+			result.Output = stderr.String()
 		}
 		return result, parseErr
 	}

--- a/cli/internal/runner/security.go
+++ b/cli/internal/runner/security.go
@@ -71,6 +71,7 @@ func (r *Runner) RunSecurity() (output.CheckResult, error) {
 		if err != nil {
 			result.Status = "error"
 			result.Message = "security check failed"
+			result.Output = stderrJSON.String()
 		}
 		return result, parseErr
 	}

--- a/cli/internal/runner/test.go
+++ b/cli/internal/runner/test.go
@@ -56,6 +56,7 @@ func (r *Runner) RunTest() (output.CheckResult, error) {
 	if err != nil {
 		result.Status = "fail"
 		result.Message = "tests failed"
+		result.Output = outputStr
 		return result, nil
 	}
 


### PR DESCRIPTION
## Summary
When CI checks fail (test, lint, security), the actual command output was being discarded, leaving only generic error messages in GitHub Actions logs. This made debugging CI failures difficult.

## Changes
- Add `Output` field to CheckResult struct to carry verbose command output
- Populate output when go test, golangci-lint, or govulncheck fail
- Display command output in GitHub Actions logs and PR comments
- Print output in CLI text mode for local debugging

## Testing
- All CLI tests pass
- Changes are backward compatible (output field is optional)
- Action YAML safely handles missing output field via jq defaults

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>