### PR TITLE
fix: update release-please config for Go CLI

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "release-type": "node",
+  "release-type": "simple",
   "package-name": "go-actions",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
@@ -15,12 +15,7 @@
     {"type": "build", "section": "Build System", "hidden": true},
     {"type": "ci", "section": "Continuous Integration", "hidden": true}
   ],
-  "extra-files": [
-    "scripts-dist/**/*.js"
-  ],
   "packages": {
-    ".": {
-      "release-as": "3.0.1"
-    }
+    ".": {}
   }
 }


### PR DESCRIPTION
## Summary

Fixed release-please configuration to match the Go CLI project structure:
- Changed release-type from `node` to `simple` (project is now pure Go, no Node.js)
- Removed stale `extra-files` referencing deleted scripts-dist JS files
- Removed one-time `release-as` override (v3.0.1 is now the manifest version)

This resolves the duplicate PR issue where release-please was creating two separate release tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)