### PR TITLE
fix: restore component name in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,8 @@
     {"type": "ci", "section": "Continuous Integration", "hidden": true}
   ],
   "packages": {
-    ".": {}
+    ".": {
+      "component": "go-actions"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- PR #51 removed the `component` field from the release-please package config
- Without it, release-please can't find the existing `go-actions-v3.0.1` tag and computes version from scratch
- This caused it to create an erroneous v2.0.0 release PR (#53, now closed)
- Restores `"component": "go-actions"` so release-please matches the `go-actions-v*` tag prefix

## Test plan
- [ ] Verify release-please no longer creates a v2.0.0 PR
- [ ] Verify release-please creates PRs on the correct branch (`release-please--branches--main--components--go-actions`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)