### PR TITLE
fix: remove duplicate release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,4 @@
 {
-  "release-type": "simple",
-  "package-name": "go-actions",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},
@@ -17,7 +15,9 @@
   ],
   "packages": {
     ".": {
-      "component": "go-actions"
+      "release-type": "simple",
+      "component": "go-actions",
+      "package-name": "go-actions"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removed top-level `release-type` and `package-name` from release-please-config.json
- Moved all release config under the package definition
- Prevents Release Please v16+ from creating duplicate "default" release PR alongside component-scoped release

## Problem
Top-level fields caused a stale v2.0.0 release PR (#57) to be created alongside the correct v3.1.0 release. This is fixed by scoping all fields under the package definition.

## Test Plan
- ✅ All CLI tests pass
- ✅ Closed stale v2 release PR (#57) and its branch
- ✅ Verified correct v3.1.0 release PR (#41) still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)