### PR TITLE
fix: use correct action inputs and quote shell variables

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,8 +174,7 @@ jobs:
         continue-on-error: true
         with:
           job: test
-        env:
-          WORKING_DIR: test-project
+          working-directory: test-project
 
       - name: Test self-validate action with major tag
         uses: jrschumacher/go-actions/self-validate@main

--- a/.github/workflows/validate-actions.yaml
+++ b/.github/workflows/validate-actions.yaml
@@ -202,22 +202,19 @@ jobs:
         uses: ./go-actions/ci
         with:
           job: test
-        env:
-          WORKING_DIR: test-project
+          working-directory: test-project
 
-      - name: Test lint action with test project  
+      - name: Test lint action with test project
         uses: ./go-actions/ci
         with:
           job: lint
-        env:
-          WORKING_DIR: test-project
+          working-directory: test-project
 
       - name: Test benchmark action with test project
         uses: ./go-actions/ci
         with:
           job: benchmark
-        env:
-          WORKING_DIR: test-project
+          working-directory: test-project
 
       - name: Test self-validate action
         uses: ./go-actions/self-validate
@@ -260,9 +257,8 @@ jobs:
         uses: ./ci
         with:
           job: test
+          working-directory: broken-project
         continue-on-error: true  # Expected to fail, but shouldn't crash
-        env:
-          WORKING_DIR: broken-project
 
   test-fixtures:
     runs-on: ubuntu-latest

--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -137,8 +137,8 @@ runs:
         fi
 
         echo "Installing golangci-lint $version..."
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $version
-        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "$version"
+        echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
         golangci-lint version
 
     - name: Install govulncheck

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/jrschumacher/go-actions/cli/internal/config"
 	"github.com/spf13/cobra"
@@ -82,12 +83,9 @@ func detectProjectSettings(cfg *config.Config) error {
 		if info.IsDir() && (info.Name() == "vendor" || info.Name() == ".git") {
 			return filepath.SkipDir
 		}
-		if filepath.Ext(path) == ".go" && filepath.Base(path) != "go.mod" {
-			// Check if it's a test file
-			if len(filepath.Base(path)) > 8 && filepath.Base(path)[len(filepath.Base(path))-8:] == "_test.go" {
-				hasTests = true
-				return filepath.SkipAll
-			}
+		if strings.HasSuffix(path, "_test.go") {
+			hasTests = true
+			return filepath.SkipAll
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
- **WORKING_DIR env var → working-directory input**: Test workflows were setting `env: WORKING_DIR` but the CI action only reads `inputs.working-directory` via `with:`. Tests were silently running against `.` instead of the intended project directory.
- **Quote shell variables**: `$(go env GOPATH)/bin` and `$version` in the golangci-lint install command are now properly quoted.
- **Simplify test file detection**: Replace fragile manual string slicing with `strings.HasSuffix(path, "_test.go")` in `cli/cmd/init.go`.

## Test plan
- [x] `cd cli && go test ./...` passes
- [ ] Merge to main and verify release-please only creates a single v3.x PR (no ghost v2 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)