### PR TITLE
fix: separate stderr from JSON output to prevent corruption

### DIFF
--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -170,8 +170,15 @@ runs:
           comment_flag="--github-comment"
         fi
 
-        /tmp/go-actions check ${{ inputs.job }} --format=json $comment_flag > /tmp/result.json 2>&1
+        /tmp/go-actions check ${{ inputs.job }} --format=json $comment_flag > /tmp/result.json 2>/tmp/result.stderr
         exit_code=$?
+
+        # Show stderr warnings in logs (kept separate from JSON output)
+        if [ -s /tmp/result.stderr ]; then
+          echo "--- Stderr ---"
+          cat /tmp/result.stderr
+          echo "--- End stderr ---"
+        fi
 
         echo "--- Raw output ---"
         cat /tmp/result.json

--- a/self-validate/action.yaml
+++ b/self-validate/action.yaml
@@ -37,12 +37,17 @@ runs:
       working-directory: ${{ github.workspace }}
       run: |
         # Run the pre-built Go CLI validator (avoids go download messages in output)
-        if output=$(/tmp/go-actions-validator validate --format json --quiet 2>&1); then
+        if output=$(/tmp/go-actions-validator validate --format json --quiet 2>/tmp/validate.stderr); then
           echo "validation_passed=true" >> $GITHUB_OUTPUT
           echo "result=$output" >> $GITHUB_OUTPUT
         else
           echo "validation_passed=false" >> $GITHUB_OUTPUT
           echo "result=$output" >> $GITHUB_OUTPUT
+        fi
+
+        # Show stderr warnings in logs
+        if [ -s /tmp/validate.stderr ]; then
+          cat /tmp/validate.stderr >&2
         fi
 
         # Always output the JSON for downstream processing


### PR DESCRIPTION
## Summary
Fixes JSON parsing failures when stderr warnings get mixed into JSON output via `2>&1` redirection. Warnings like "failed to post GitHub comment" were corrupting the JSON, causing jq parsing to fail in downstream steps.

## Changes
- **ci/action.yaml**: Separate stderr to temp file while keeping it visible in logs
- **self-validate/action.yaml**: Same fix for validation output

## Result
JSON output remains clean and parseable, while stderr warnings are still visible in GitHub Actions logs for debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)