### PR TITLE
fix: update PATH in current shell before running golangci-lint

### DIFF
--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -137,8 +137,10 @@ runs:
         fi
 
         echo "Installing golangci-lint $version..."
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "$version"
-        echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        GOBIN="$(go env GOPATH)/bin"
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$GOBIN" "$version"
+        echo "$GOBIN" >> "$GITHUB_PATH"
+        export PATH="$GOBIN:$PATH"
         golangci-lint version
 
     - name: Install govulncheck


### PR DESCRIPTION
## Summary
Fixed lint job crashes caused by `golangci-lint version` unable to find the binary. The issue was that GITHUB_PATH updates only take effect in subsequent steps, but the version check runs in the same step.

## Changes
- Export PATH in current shell after installing golangci-lint
- Store GOBIN in variable to avoid redundant `go env` calls
- Ensures golangci-lint binary is immediately available in the same step

Fixes CI workflows where the lint job exits with code 1 during installation.

🤖 Generated with Claude Code