### PR TITLE
fix: clean stale Go module cache on self-hosted runners before setup-go

### DIFF
--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -85,6 +85,14 @@ runs:
           exit 1
         fi
 
+    - name: Clean stale Go module cache (self-hosted workaround)
+      # Works around actions/setup-go cache restore failing with
+      # "tar: Cannot open: File exists" when the module download cache persists
+      # between jobs on self-hosted runners. See issue #74.
+      if: runner.environment == 'self-hosted' || contains(runner.labels, 'self-hosted')
+      shell: bash
+      run: rm -rf "${GOPATH:-$HOME/go}/pkg/mod/cache/download" || true
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -46,6 +46,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Clean stale Go module cache (self-hosted workaround)
+      # Works around actions/setup-go cache restore failing with
+      # "tar: Cannot open: File exists" when the module download cache persists
+      # between jobs on self-hosted runners. See issue #74.
+      if: runner.environment == 'self-hosted' || contains(runner.labels, 'self-hosted')
+      shell: bash
+      run: rm -rf "${GOPATH:-$HOME/go}/pkg/mod/cache/download" || true
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Summary

- Adds a pre-step to `ci/action.yaml` and `release/action.yaml` that removes `$GOMODCACHE/download` before `actions/setup-go@v5` runs.
- Gated on `runner.environment == 'self-hosted' || contains(runner.labels, 'self-hosted')` so GitHub-hosted runners are unaffected.
- Fixes #74 (the `tar: Cannot open: File exists` failure during `setup-go` cache restore on self-hosted runners).

Follow-up self-hosted concerns tracked in #76.

## Test plan

- [x] `cd cli && go test ./...` passes.
- [x] `yq` confirms both action YAMLs parse and the new step is positioned before `Set up Go`.
- [ ] Verify on a self-hosted runner that previously reproduced the `tar: File exists` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)