### PR TITLE
fix: harden actions for self-hosted runners (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,32 @@ Wails desktop apps have specific CI/CD challenges — CGO dependencies, frontend
 
 ---
 
+## Self-hosted runner requirements
+
+go-actions works on GitHub-hosted runners out of the box. On self-hosted runners, **ephemeral runners are strongly recommended** — Actions Runner Controller (ARC) or ScaleSets configured with `--ephemeral` so each job runs in a fresh container. This is the same posture GitHub itself recommends, and `actions/setup-go`'s caching is only officially supported on GitHub-hosted and ephemeral self-hosted runners.
+
+The action transparently handles the most common self-hosted hazards: it writes all intermediate artifacts to a per-job scratch dir under `$RUNNER_TEMP`, installs `golangci-lint` / `govulncheck` into a job-scoped `GOBIN` so pinned versions in one repo can't overwrite another's, and cleans `$GOPATH/pkg/mod` and `$HOME/.cache/go-build` before `setup-go` runs (only when a self-hosted runner is detected).
+
+If you must run on **persistent** self-hosted runners, these items are your responsibility:
+
+### Runner prerequisites
+
+The action assumes the following tools are on `PATH`: `bash`, `curl`, `git`, `jq`, `tar`. Minimal ARC images (e.g., stock `actions/runner`) often lack `jq` — install it in your runner image. The runner user must own `$HOME` and `$GOPATH` (no stray root-owned files from prior jobs).
+
+### Unbounded caches
+
+`$HOME/.cache/golangci-lint` grows forever on persistent runners and is sensitive to golangci-lint version changes (a cache primed by v2.9 can produce odd results against v2.11). Prune it periodically or mount it as a tmpfs that resets between jobs.
+
+### Concurrent job races
+
+On a static self-hosted host with multiple jobs assigned to the same runner, two jobs starting within seconds of each other can race the cleanup step against `setup-go`. Ephemeral runners eliminate this. On static pools, serialize jobs per runner or accept occasional `tar: File exists` retries.
+
+### Stale working-directory files
+
+If the calling workflow sets `actions/checkout` with `clean: false`, a stale `coverage.out` or other build artifacts can linger between jobs. `go test` overwrites `coverage.out`, but this is one more reason to prefer ephemeral runners or the default `clean: true`.
+
+---
+
 ## Version Policy
 
 - **`@v3`**: Latest stable v3.x.x release (recommended)

--- a/ci/action.yaml
+++ b/ci/action.yaml
@@ -85,13 +85,34 @@ runs:
           exit 1
         fi
 
-    - name: Clean stale Go module cache (self-hosted workaround)
+    - name: Setup go-actions scratch dir
+      # Per-job scratch dir isolates this job's tool binaries, built CLI, and
+      # intermediate result files from other jobs sharing a self-hosted runner.
+      # RUNNER_TEMP is scoped per job and cleaned by the runner.
+      shell: bash
+      run: |
+        scratch="${RUNNER_TEMP}/go-actions-${GITHUB_JOB}"
+        mkdir -p "$scratch/gobin"
+        echo "GO_ACTIONS_SCRATCH=$scratch" >> "$GITHUB_ENV"
+        echo "GOBIN=$scratch/gobin" >> "$GITHUB_ENV"
+        echo "$scratch/gobin" >> "$GITHUB_PATH"
+
+    - name: Clean stale Go build and module caches (self-hosted workaround)
       # Works around actions/setup-go cache restore failing with
-      # "tar: Cannot open: File exists" when the module download cache persists
-      # between jobs on self-hosted runners. See issue #74.
+      # "tar: Cannot open: File exists" when cache dirs persist between jobs
+      # on self-hosted runners. Covers both GOMODCACHE and GOCACHE since
+      # setup-go restores/saves both. See issues #74 and #76.
       if: runner.environment == 'self-hosted' || contains(runner.labels, 'self-hosted')
       shell: bash
-      run: rm -rf "${GOPATH:-$HOME/go}/pkg/mod/cache/download" || true
+      run: |
+        warn_on_fail() {
+          local path="$1"
+          if [ -e "$path" ] && ! rm -rf "$path" 2>/dev/null; then
+            echo "::warning::Failed to clean $path (non-fatal, but setup-go may error)"
+          fi
+        }
+        warn_on_fail "${GOPATH:-$HOME/go}/pkg/mod"
+        warn_on_fail "$HOME/.cache/go-build"
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -106,7 +127,7 @@ runs:
       run: |
         echo "Building go-actions CLI..."
         cd "$ACTION_PATH/../cli"
-        go build -o /tmp/go-actions ./cmd/go-actions
+        go build -o "$GO_ACTIONS_SCRATCH/go-actions" ./cmd/go-actions
         echo "✅ CLI built successfully"
 
     - name: Install golangci-lint
@@ -115,7 +136,6 @@ runs:
       run: |
         go_version=$(go version | awk '{print $3}' | sed 's/go//')
         go_minor=$(echo "$go_version" | cut -d. -f2)
-        GOBIN="$(go env GOPATH)/bin"
 
         # Fetch the latest golangci-lint version from GitHub
         version=$(curl -sS https://api.github.com/repos/golangci/golangci-lint/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
@@ -127,9 +147,10 @@ runs:
 
         # Try prebuilt binary first (fast), fall back to source install if
         # the binary was built with an older Go than the project targets.
-        echo "Installing golangci-lint $version..."
+        # Install to job-scoped GOBIN so a pinned version in one repo can't
+        # overwrite another's on a shared runner.
+        echo "Installing golangci-lint $version to $GOBIN..."
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$GOBIN" "$version"
-        echo "$GOBIN" >> "$GITHUB_PATH"
         export PATH="$GOBIN:$PATH"
 
         # Check if the prebuilt binary's Go version is compatible
@@ -150,9 +171,8 @@ runs:
       env:
         GOVULNCHECK_VERSION: ${{ inputs.govulncheck-version }}
       run: |
-        echo "Installing govulncheck..."
+        echo "Installing govulncheck to $GOBIN..."
         go install "golang.org/x/vuln/cmd/govulncheck@$GOVULNCHECK_VERSION"
-        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Run check
       id: run-check
@@ -177,27 +197,30 @@ runs:
           comment_flag="--github-comment"
         fi
 
-        /tmp/go-actions check "$JOB" --format=json $comment_flag > /tmp/result.json 2>/tmp/result.stderr
+        result_json="$GO_ACTIONS_SCRATCH/result.json"
+        result_stderr="$GO_ACTIONS_SCRATCH/result.stderr"
+
+        "$GO_ACTIONS_SCRATCH/go-actions" check "$JOB" --format=json $comment_flag > "$result_json" 2>"$result_stderr"
         exit_code=$?
 
         # Show stderr warnings in logs (kept separate from JSON output)
-        if [ -s /tmp/result.stderr ]; then
+        if [ -s "$result_stderr" ]; then
           echo "--- Stderr ---"
-          cat /tmp/result.stderr
+          cat "$result_stderr"
           echo "--- End stderr ---"
         fi
 
         echo "--- Raw output ---"
-        cat /tmp/result.json
+        cat "$result_json"
         echo "--- End output ---"
 
         # Parse JSON output using jq for reliable parsing
-        if [ -f /tmp/result.json ] && command -v jq &> /dev/null && jq -e '.status' /tmp/result.json > /dev/null 2>&1; then
-          status=$(jq -r '.status // "unknown"' /tmp/result.json)
-          coverage=$(jq -r '.checks[0].coverage // 0' /tmp/result.json)
-          issues=$(jq -r '.checks[0].issues // 0' /tmp/result.json)
-          vulns=$(jq -r '.checks[0].vulnerabilities // 0' /tmp/result.json)
-          message=$(jq -r '.checks[0].message // ""' /tmp/result.json)
+        if [ -f "$result_json" ] && command -v jq &> /dev/null && jq -e '.status' "$result_json" > /dev/null 2>&1; then
+          status=$(jq -r '.status // "unknown"' "$result_json")
+          coverage=$(jq -r '.checks[0].coverage // 0' "$result_json")
+          issues=$(jq -r '.checks[0].issues // 0' "$result_json")
+          vulns=$(jq -r '.checks[0].vulnerabilities // 0' "$result_json")
+          message=$(jq -r '.checks[0].message // ""' "$result_json")
 
           echo "status=${status}" >> $GITHUB_OUTPUT
           echo "coverage=${coverage}" >> $GITHUB_OUTPUT
@@ -212,7 +235,7 @@ runs:
           [ -n "$message" ] && [ "$message" != "null" ] && echo "  Message: ${message}"
 
           # Display command output if present (e.g., test failure details)
-          check_output=$(jq -r '.checks[0].output // ""' /tmp/result.json)
+          check_output=$(jq -r '.checks[0].output // ""' "$result_json")
           if [ -n "$check_output" ] && [ "$check_output" != "null" ]; then
             echo ""
             echo "--- Command Output ---"

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -46,13 +46,31 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Clean stale Go module cache (self-hosted workaround)
+    - name: Setup go-actions scratch dir
+      # Per-job scratch dir isolates this job's built CLI from other jobs
+      # sharing a self-hosted runner. RUNNER_TEMP is scoped per job.
+      shell: bash
+      run: |
+        scratch="${RUNNER_TEMP}/go-actions-${GITHUB_JOB}"
+        mkdir -p "$scratch"
+        echo "GO_ACTIONS_SCRATCH=$scratch" >> "$GITHUB_ENV"
+
+    - name: Clean stale Go build and module caches (self-hosted workaround)
       # Works around actions/setup-go cache restore failing with
-      # "tar: Cannot open: File exists" when the module download cache persists
-      # between jobs on self-hosted runners. See issue #74.
+      # "tar: Cannot open: File exists" when cache dirs persist between jobs
+      # on self-hosted runners. Covers both GOMODCACHE and GOCACHE since
+      # setup-go restores/saves both. See issues #74 and #76.
       if: runner.environment == 'self-hosted' || contains(runner.labels, 'self-hosted')
       shell: bash
-      run: rm -rf "${GOPATH:-$HOME/go}/pkg/mod/cache/download" || true
+      run: |
+        warn_on_fail() {
+          local path="$1"
+          if [ -e "$path" ] && ! rm -rf "$path" 2>/dev/null; then
+            echo "::warning::Failed to clean $path (non-fatal, but setup-go may error)"
+          fi
+        }
+        warn_on_fail "${GOPATH:-$HOME/go}/pkg/mod"
+        warn_on_fail "$HOME/.cache/go-build"
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -67,7 +85,7 @@ runs:
       run: |
         echo "Building go-actions CLI..."
         cd "$ACTION_PATH/../cli"
-        go build -o /tmp/go-actions ./cmd/go-actions
+        go build -o "$GO_ACTIONS_SCRATCH/go-actions" ./cmd/go-actions
         echo "CLI built successfully"
 
     - name: Read release config
@@ -84,7 +102,7 @@ runs:
           goreleaser_args="$GORELEASER_ARGS_INPUT"
           echo "Using goreleaser args from action input: $goreleaser_args"
         elif [ -f ".go-actions.yaml" ]; then
-          config_args=$(/tmp/go-actions config get release.goreleaser.args 2>/dev/null || echo "")
+          config_args=$("$GO_ACTIONS_SCRATCH/go-actions" config get release.goreleaser.args 2>/dev/null || echo "")
           if [ -n "$config_args" ]; then
             goreleaser_args="$config_args"
             echo "Using goreleaser args from .go-actions.yaml: $goreleaser_args"

--- a/self-validate/action.yaml
+++ b/self-validate/action.yaml
@@ -18,6 +18,15 @@ runs:
     # Note: The calling workflow must check out the repository before using this action.
     # We don't do checkout here to avoid overwriting files created by the calling workflow.
 
+    - name: Setup go-actions scratch dir
+      # Per-job scratch dir isolates this job's built CLI from other jobs
+      # sharing a self-hosted runner. RUNNER_TEMP is scoped per job.
+      shell: bash
+      run: |
+        scratch="${RUNNER_TEMP}/go-actions-${GITHUB_JOB}"
+        mkdir -p "$scratch"
+        echo "GO_ACTIONS_SCRATCH=$scratch" >> "$GITHUB_ENV"
+
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
@@ -30,7 +39,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
       run: |
         cd "$ACTION_PATH/../cli"
-        go build -o /tmp/go-actions-validator ./cmd/go-actions
+        go build -o "$GO_ACTIONS_SCRATCH/go-actions-validator" ./cmd/go-actions
         echo "✅ CLI built successfully"
 
     - name: Run validation
@@ -38,8 +47,9 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       run: |
+        stderr="$GO_ACTIONS_SCRATCH/validate.stderr"
         # Run the pre-built Go CLI validator (avoids go download messages in output)
-        if output=$(/tmp/go-actions-validator validate --format json --quiet 2>/tmp/validate.stderr); then
+        if output=$("$GO_ACTIONS_SCRATCH/go-actions-validator" validate --format json --quiet 2>"$stderr"); then
           echo "validation_passed=true" >> $GITHUB_OUTPUT
           echo "result=$output" >> $GITHUB_OUTPUT
         else
@@ -48,8 +58,8 @@ runs:
         fi
 
         # Show stderr warnings in logs
-        if [ -s /tmp/validate.stderr ]; then
-          cat /tmp/validate.stderr >&2
+        if [ -s "$stderr" ]; then
+          cat "$stderr" >&2
         fi
 
         # Always output the JSON for downstream processing


### PR DESCRIPTION
## Summary

Addresses Category A items from #76: per-job scratch dir under `$RUNNER_TEMP` for the built CLI and result files (A1), job-scoped `GOBIN` so pinned tool versions don't leak across repos on shared runners (A2), `::warning::` annotations instead of silent `|| true` on cleanup failures (A3), and extended self-hosted cleanup to cover both `$GOMODCACHE` and `$GOCACHE` — not just `$GOMODCACHE/download` — since `setup-go` restores both (A4).

Also adds a "Self-hosted runner requirements" section to the README recommending ephemeral runners (ARC/ScaleSets with \`--ephemeral\`) and documenting prerequisites, unbounded caches, concurrent-runner \`rm\` races, and stale working-dir files (Category B items — documented not fixed, per the issue's guidance).

## Test plan

- [x] \`cd cli && go test ./...\` passes
- [x] YAML parses cleanly in all three action files
- [ ] Run \`ci/\` action on a test workflow (test, lint, security jobs) on GitHub-hosted runner
- [ ] Run \`ci/\` action on a self-hosted runner to confirm cleanup + scratch-dir behavior
- [ ] Run \`release/\` action on a test workflow
- [ ] Run \`self-validate/\` action on a test workflow

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)